### PR TITLE
hostfix/diagnosticsFromScratch

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -221,7 +221,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "aks-node" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "aks-diagnostics" {
-  count                      = var.oms_workspace_id != "" ? 1 : 0
+  count                      = var.enable_diagnostics ? 1 : 0
   name                       = "diag-${var.cluster_name}"
   target_resource_id         = azurerm_kubernetes_cluster.k8s_cluster.id
   log_analytics_workspace_id = var.oms_workspace_id

--- a/variables.tf
+++ b/variables.tf
@@ -176,5 +176,7 @@ variable "oms_agent_enable" {
   default     = true
 }
 
-
+variable "enable_diagnostics" {
+  default = false
+}
 

--- a/variables.tf
+++ b/variables.tf
@@ -178,5 +178,6 @@ variable "oms_agent_enable" {
 
 variable "enable_diagnostics" {
   default = false
+  type    = bool
 }
 


### PR DESCRIPTION
When building from scratch the test for enabling aks diagnostics would fail because it does not know the value when running plan. A new variable is added to remedy this situation