### PR TITLE
add optional variable "agent_net_name" for vnet

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -90,7 +90,7 @@ locals {
 }
 
 resource "azurerm_virtual_network" "k8s_agent_network" {
-  name                = "agent-net"
+  name                = var.agent_net_name 
   location            = var.resource_group_location
   resource_group_name = var.resource_group_name
   address_space       = [var.aks_vnet_subnet_cidr]

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "resource_group_location" {
 }
 
 ## AKS variables ##
+variable "agent_net_name" {
+  type        = string
+  description = "Optional name of the agent vnet"
+  default     = "agent-net"
+}
+
 variable "k8s_version" {
   description = "What version of k8s to request from provider"
   default     = "1.11.4"


### PR DESCRIPTION
Think the comment speaks for itself:
You can now optionally name the k8s_agent_network 👍 